### PR TITLE
Add powerline-style segments with themes from claude-powerline

### DIFF
--- a/.claude-limitline.example.json
+++ b/.claude-limitline.example.json
@@ -1,17 +1,26 @@
 {
   "display": {
-    "style": "minimal",
+    "style": "powerline",
     "useNerdFonts": true
+  },
+  "directory": {
+    "enabled": true
+  },
+  "git": {
+    "enabled": true
+  },
+  "model": {
+    "enabled": true
   },
   "block": {
     "enabled": true,
-    "displayStyle": "bar",
+    "displayStyle": "text",
     "barWidth": 10,
     "showTimeRemaining": true
   },
   "weekly": {
     "enabled": true,
-    "displayStyle": "bar",
+    "displayStyle": "text",
     "barWidth": 10,
     "showWeekProgress": true
   },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-limitline
 
-A statusline for Claude Code showing real-time usage limits and weekly tracking.
+A powerline-style statusline for Claude Code showing real-time usage limits, git info, and model details.
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen.svg)
@@ -8,19 +8,27 @@ A statusline for Claude Code showing real-time usage limits and weekly tracking.
 
 ## Features
 
+- **Powerline Style** - Beautiful segmented display with smooth transitions
 - **5-Hour Block Limit** - Shows current usage percentage with time remaining until reset
 - **7-Day Rolling Limit** - Tracks weekly usage with progress indicator
-- **Real-time Tracking** - Uses Anthropic's OAuth usage API for accurate usage data
-- **Progress Bar Display** - Visual progress bars for quick status checks
+- **Repository Name** - Displays current project/directory name
+- **Git Branch** - Shows current branch with dirty indicator (●)
+- **Claude Model** - Displays the active model (Opus 4.5, Sonnet 4, etc.)
+- **Multiple Themes** - Dark, light, nord, gruvbox, tokyo-night, and rose-pine
+- **Real-time Tracking** - Uses Anthropic's OAuth usage API for accurate data
 - **Cross-Platform** - Works on Windows, macOS, and Linux
-- **Zero Runtime Dependencies** - Lightweight and fast
-- **Multiple Themes** - Dark, light, nord, and gruvbox themes included
+
+## Example Output
+
+```
+ claude-limitline  main ●   Opus 4.5   12% (3h20m)   45% (wk 85%)
+```
 
 ## Prerequisites
 
 - **Node.js** 18.0.0 or higher
 - **Claude Code** CLI installed and authenticated (for OAuth token)
-- **Nerd Font** (optional, for powerline symbols)
+- **Nerd Font** (recommended, for powerline symbols)
 
 ## Installation
 
@@ -40,21 +48,9 @@ npm run build
 npm link
 ```
 
-### Using Docker
-
-```bash
-# Build the image
-docker build -t claude-limitline .
-
-# Run (mount your .claude directory for OAuth token access)
-docker run --rm -v ~/.claude:/root/.claude claude-limitline
-```
-
 ## Quick Start
 
-The easiest way to use claude-limitline is to add it directly to your Claude Code settings.
-
-**Add to your Claude Code settings file** (`~/.claude/settings.json`):
+Add claude-limitline to your Claude Code settings file (`~/.claude/settings.json`):
 
 ```json
 {
@@ -65,27 +61,9 @@ The easiest way to use claude-limitline is to add it directly to your Claude Cod
 }
 ```
 
-That's it! The status line will now show your usage limits in Claude Code.
+That's it! The status line will now show in Claude Code.
 
-### Full Settings Example
-
-Here's a complete example with other common settings:
-
-```json
-{
-  "permissions": {
-    "defaultMode": "default"
-  },
-  "statusLine": {
-    "type": "command",
-    "command": "npx claude-limitline"
-  }
-}
-```
-
-### Alternative: Global Install
-
-If you prefer a global installation (slightly faster startup):
+### Global Install (faster startup)
 
 ```bash
 npm install -g claude-limitline
@@ -107,12 +85,8 @@ Then update your settings:
 Run standalone to verify it's working:
 
 ```bash
-npx claude-limitline
-```
-
-You should see output like:
-```
-⏳ ████████░░ 45% (2h 30m left) | 📅 ██████░░░░ 62% (wk 43%)
+# Simulate Claude Code hook data
+echo '{"model":{"id":"claude-opus-4-5-20251101"}}' | npx claude-limitline
 ```
 
 ## Configuration
@@ -122,18 +96,27 @@ Create a `.claude-limitline.json` file in your home directory (`~/.claude-limitl
 ```json
 {
   "display": {
-    "style": "minimal",
+    "style": "powerline",
     "useNerdFonts": true
+  },
+  "directory": {
+    "enabled": true
+  },
+  "git": {
+    "enabled": true
+  },
+  "model": {
+    "enabled": true
   },
   "block": {
     "enabled": true,
-    "displayStyle": "bar",
+    "displayStyle": "text",
     "barWidth": 10,
     "showTimeRemaining": true
   },
   "weekly": {
     "enabled": true,
-    "displayStyle": "bar",
+    "displayStyle": "text",
     "barWidth": 10,
     "showWeekProgress": true
   },
@@ -149,13 +132,16 @@ Create a `.claude-limitline.json` file in your home directory (`~/.claude-limitl
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `display.useNerdFonts` | Use Nerd Font symbols (⏳📅) vs ASCII | `true` |
+| `display.useNerdFonts` | Use Nerd Font symbols for powerline | `true` |
+| `directory.enabled` | Show repository/directory name | `true` |
+| `git.enabled` | Show git branch with dirty indicator | `true` |
+| `model.enabled` | Show Claude model name | `true` |
 | `block.enabled` | Show 5-hour block usage | `true` |
-| `block.displayStyle` | `"bar"` or `"text"` | `"bar"` |
+| `block.displayStyle` | `"bar"` or `"text"` | `"text"` |
 | `block.barWidth` | Width of progress bar in characters | `10` |
 | `block.showTimeRemaining` | Show time until block resets | `true` |
 | `weekly.enabled` | Show 7-day rolling usage | `true` |
-| `weekly.displayStyle` | `"bar"` or `"text"` | `"bar"` |
+| `weekly.displayStyle` | `"bar"` or `"text"` | `"text"` |
 | `weekly.barWidth` | Width of progress bar in characters | `10` |
 | `weekly.showWeekProgress` | Show week progress percentage | `true` |
 | `budget.pollInterval` | Minutes between API calls | `15` |
@@ -164,29 +150,39 @@ Create a `.claude-limitline.json` file in your home directory (`~/.claude-limitl
 
 ### Available Themes
 
-- `dark` - Default dark theme
-- `light` - Light background theme
+- `dark` - Default dark theme with warm browns and cool cyans
+- `light` - Light background theme with vibrant colors
 - `nord` - Nord color palette
 - `gruvbox` - Gruvbox color palette
+- `tokyo-night` - Tokyo Night color palette
+- `rose-pine` - Rosé Pine color palette
+
+## Segments
+
+The statusline displays the following segments (all configurable):
+
+| Segment | Description | Color (dark theme) |
+|---------|-------------|-------------------|
+| **Directory** | Current repo/project name | Brown/Orange |
+| **Git** | Branch name + dirty indicator (●) | Dark Gray |
+| **Model** | Claude model (Opus 4.5, Sonnet 4, etc.) | Dark Gray |
+| **Block** | 5-hour usage % + time remaining | Cyan (warning: Orange, critical: Red) |
+| **Weekly** | 7-day usage % + week progress | Green |
 
 ## How It Works
 
-claude-limitline retrieves your Claude usage data from Anthropic's OAuth usage API. It reads your OAuth token from:
+claude-limitline retrieves data from two sources:
+
+1. **Hook Data (stdin)** - Claude Code passes JSON with model info, workspace, and session data
+2. **Usage API** - Fetches usage limits from Anthropic's OAuth usage endpoint
+
+### OAuth Token Location
 
 | Platform | Location |
 |----------|----------|
 | **Windows** | Credential Manager or `~/.claude/.credentials.json` |
 | **macOS** | Keychain or `~/.claude/.credentials.json` |
 | **Linux** | secret-tool (GNOME Keyring) or `~/.claude/.credentials.json` |
-
-The usage data is cached locally to respect API rate limits. The cache duration is configurable via `budget.pollInterval` (default: 15 minutes).
-
-### API Response
-
-The tool queries Anthropic's usage endpoint which returns:
-
-- **5-hour block**: Usage percentage and reset time for the rolling 5-hour window
-- **7-day rolling**: Usage percentage and reset time for the rolling 7-day window
 
 ## Development
 
@@ -210,16 +206,13 @@ npm run build
 npm run dev
 ```
 
-### Type Checking
-
-```bash
-npm run typecheck
-```
-
 ### Run Locally
 
 ```bash
 node dist/index.js
+
+# With simulated hook data
+echo '{"model":{"id":"claude-opus-4-5-20251101"}}' | node dist/index.js
 ```
 
 ## Debug Mode
@@ -241,25 +234,22 @@ Debug output is written to stderr so it won't interfere with the status line out
 
 ## Troubleshooting
 
+### Model not showing
+
+The model is passed via stdin from Claude Code. If running standalone, pipe in hook data:
+```bash
+echo '{"model":{"id":"claude-opus-4-5-20251101"}}' | claude-limitline
+```
+
 ### "No data" or empty output
 
 1. **Check OAuth token**: Make sure you're logged into Claude Code (`claude --login`)
-2. **Check credentials file**: Verify `~/.claude/.credentials.json` exists and contains `claudeAiOauth.accessToken`
-3. **Enable debug mode**: Run with `CLAUDE_LIMITLINE_DEBUG=true` to see detailed logs
+2. **Check credentials file**: Verify `~/.claude/.credentials.json` exists
+3. **Enable debug mode**: Run with `CLAUDE_LIMITLINE_DEBUG=true`
 
-### Token not found
+### Git branch not showing
 
-The OAuth token is stored by Claude Code when you authenticate. Try:
-
-```bash
-# Re-authenticate with Claude Code
-claude --login
-```
-
-### API returns errors
-
-- Ensure your Claude subscription is active
-- Check if you've exceeded API rate limits (try increasing `pollInterval`)
+Make sure you're in a git repository. The git segment only appears when a `.git` directory is found.
 
 ## Contributing
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,2 +1,2 @@
 export { loadConfig } from "./loader.js";
-export { DEFAULT_CONFIG, type LimitlineConfig, type BlockSegmentConfig, type WeeklySegmentConfig, type BudgetConfig, type DisplayConfig } from "./types.js";
+export { DEFAULT_CONFIG, type LimitlineConfig, type BlockSegmentConfig, type WeeklySegmentConfig, type BudgetConfig, type DisplayConfig, type SimpleSegmentConfig } from "./types.js";

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -4,6 +4,10 @@ export interface SegmentConfig {
   barWidth?: number;
 }
 
+export interface SimpleSegmentConfig {
+  enabled: boolean;
+}
+
 export interface BlockSegmentConfig extends SegmentConfig {
   showTimeRemaining?: boolean;
 }
@@ -27,6 +31,9 @@ export interface DisplayConfig {
 
 export interface LimitlineConfig {
   display?: DisplayConfig;
+  directory?: SimpleSegmentConfig;  // Show repo/directory name
+  git?: SimpleSegmentConfig;        // Show git branch
+  model?: SimpleSegmentConfig;      // Show Claude model
   block?: BlockSegmentConfig;
   weekly?: WeeklySegmentConfig;
   budget?: BudgetConfig;
@@ -35,18 +42,27 @@ export interface LimitlineConfig {
 
 export const DEFAULT_CONFIG: LimitlineConfig = {
   display: {
-    style: "minimal",
+    style: "powerline",
     useNerdFonts: true,
+  },
+  directory: {
+    enabled: true,
+  },
+  git: {
+    enabled: true,
+  },
+  model: {
+    enabled: true,
   },
   block: {
     enabled: true,
-    displayStyle: "bar",
+    displayStyle: "text",
     barWidth: 10,
     showTimeRemaining: true,
   },
   weekly: {
     enabled: true,
-    displayStyle: "bar",
+    displayStyle: "text",
     barWidth: 10,
     showWeekProgress: true,
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { loadConfig } from "./config/index.js";
 import { BlockProvider } from "./segments/block.js";
 import { WeeklyProvider } from "./segments/weekly.js";
 import { Renderer } from "./renderer.js";
+import { getEnvironmentInfo } from "./utils/environment.js";
+import { readHookData } from "./utils/claude-hook.js";
 import { debug } from "./utils/logger.js";
 
 async function main(): Promise<void> {
@@ -11,6 +13,14 @@ async function main(): Promise<void> {
     // Load configuration
     const config = loadConfig();
     debug("Config loaded:", JSON.stringify(config));
+
+    // Read hook data from stdin (Claude Code passes this)
+    const hookData = await readHookData();
+    debug("Hook data:", JSON.stringify(hookData));
+
+    // Get environment info (repo name, git branch, model)
+    const envInfo = getEnvironmentInfo(hookData);
+    debug("Environment info:", JSON.stringify(envInfo));
 
     // Initialize providers
     const blockProvider = new BlockProvider();
@@ -36,7 +46,7 @@ async function main(): Promise<void> {
 
     // Render output
     const renderer = new Renderer(config);
-    const output = renderer.render(blockInfo, weeklyInfo);
+    const output = renderer.render(blockInfo, weeklyInfo, envInfo);
 
     if (output) {
       process.stdout.write(output);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,21 +1,31 @@
 import { SYMBOLS, TEXT_SYMBOLS, RESET_CODE } from "./utils/constants.js";
-import { getTheme, type ThemeColors } from "./themes/index.js";
+import { getTheme, ansi, hexToRaw, type ColorTheme, type SegmentColor } from "./themes/index.js";
 import { type LimitlineConfig } from "./config/index.js";
 import { type BlockInfo } from "./segments/block.js";
 import { type WeeklyInfo } from "./segments/weekly.js";
+import { type EnvironmentInfo } from "./utils/environment.js";
 
 interface SymbolSet {
   block: string;
   weekly: string;
+  rightArrow: string;
   separator: string;
+  branch: string;
+  model: string;
   progressFull: string;
   progressEmpty: string;
 }
 
+interface Segment {
+  text: string;
+  colors: SegmentColor;
+}
+
 export class Renderer {
   private config: LimitlineConfig;
-  private theme: ThemeColors;
+  private theme: ColorTheme;
   private symbols: SymbolSet;
+  private usePowerline: boolean;
 
   constructor(config: LimitlineConfig) {
     this.config = config;
@@ -23,127 +33,234 @@ export class Renderer {
 
     const useNerd = config.display?.useNerdFonts ?? true;
     const symbolSet = useNerd ? SYMBOLS : TEXT_SYMBOLS;
+    this.usePowerline = useNerd;
 
     this.symbols = {
       block: symbolSet.block_cost,
       weekly: symbolSet.weekly_cost,
+      rightArrow: symbolSet.right,
       separator: symbolSet.separator,
+      branch: symbolSet.branch,
+      model: "\uf0e7", // Lightning bolt for model
       progressFull: symbolSet.progress_full,
       progressEmpty: symbolSet.progress_empty,
     };
   }
 
-  private formatProgressBar(percent: number, width: number, colors: ThemeColors): string {
+  private formatProgressBar(percent: number, width: number): string {
     const filled = Math.round((percent / 100) * width);
     const empty = width - filled;
-
-    const filledBar = colors.progressFull + this.symbols.progressFull.repeat(filled);
-    const emptyBar = colors.progressEmpty + this.symbols.progressEmpty.repeat(empty);
-
-    return filledBar + emptyBar + RESET_CODE;
+    return this.symbols.progressFull.repeat(filled) + this.symbols.progressEmpty.repeat(empty);
   }
 
   private formatTimeRemaining(minutes: number): string {
     if (minutes >= 60) {
       const hours = Math.floor(minutes / 60);
       const mins = minutes % 60;
-      return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+      return mins > 0 ? `${hours}h${mins}m` : `${hours}h`;
     }
     return `${minutes}m`;
   }
 
-  private getColorForPercent(percent: number, colors: ThemeColors): { bg: string; fg: string } {
+  private getColorsForPercent(percent: number, baseColors: SegmentColor): SegmentColor {
     const threshold = this.config.budget?.warningThreshold ?? 80;
 
     if (percent >= 100) {
-      return { bg: colors.criticalBg, fg: colors.criticalFg };
+      return this.theme.critical;
     } else if (percent >= threshold) {
-      return { bg: colors.warningBg, fg: colors.warningFg };
+      return this.theme.warning;
     }
-    return { bg: colors.blockBg, fg: colors.blockFg };
+    return baseColors;
   }
 
-  renderBlock(blockInfo: BlockInfo | null): string {
-    if (!blockInfo || !this.config.block?.enabled) {
-      return "";
+  private renderPowerline(segments: Segment[]): string {
+    if (segments.length === 0) return "";
+
+    let output = "";
+
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i];
+      const nextColors = i < segments.length - 1 ? segments[i + 1].colors : null;
+
+      // Segment content with background and foreground
+      output += ansi.bg(seg.colors.bg) + ansi.fg(seg.colors.fg) + seg.text;
+
+      // Powerline arrow
+      output += RESET_CODE;
+      if (nextColors) {
+        // Arrow: current bg as fg, next bg as bg
+        output += ansi.fg(seg.colors.bg) + ansi.bg(nextColors.bg) + this.symbols.rightArrow;
+      } else {
+        // Final arrow to terminal background
+        output += ansi.fg(seg.colors.bg) + this.symbols.rightArrow;
+      }
     }
 
+    output += RESET_CODE;
+    return output;
+  }
+
+  private renderFallback(segments: Segment[]): string {
+    return segments
+      .map(seg => ansi.bg(seg.colors.bg) + ansi.fg(seg.colors.fg) + seg.text + RESET_CODE)
+      .join(` ${this.symbols.separator} `);
+  }
+
+  renderDirectory(envInfo: EnvironmentInfo): Segment | null {
+    if (!this.config.directory?.enabled || !envInfo.directory) {
+      return null;
+    }
+
+    return {
+      text: ` ${envInfo.directory} `,
+      colors: this.theme.directory,
+    };
+  }
+
+  renderGit(envInfo: EnvironmentInfo): Segment | null {
+    if (!this.config.git?.enabled || !envInfo.gitBranch) {
+      return null;
+    }
+
+    const dirtyIndicator = envInfo.gitDirty ? " ●" : "";
+    const icon = this.usePowerline ? this.symbols.branch : "";
+    const prefix = icon ? `${icon} ` : "";
+
+    return {
+      text: ` ${prefix}${envInfo.gitBranch}${dirtyIndicator} `,
+      colors: this.theme.git,
+    };
+  }
+
+  renderModel(envInfo: EnvironmentInfo): Segment | null {
+    if (!this.config.model?.enabled || !envInfo.model) {
+      return null;
+    }
+
+    const icon = this.usePowerline ? this.symbols.model : "";
+    const prefix = icon ? `${icon} ` : "";
+
+    return {
+      text: ` ${prefix}${envInfo.model} `,
+      colors: this.theme.model,
+    };
+  }
+
+  renderBlock(blockInfo: BlockInfo | null): Segment | null {
+    if (!blockInfo || !this.config.block?.enabled) {
+      return null;
+    }
+
+    const icon = this.usePowerline ? this.symbols.block : "BLK";
+
     if (blockInfo.percentUsed === null) {
-      return `${this.symbols.block} --`;
+      return {
+        text: ` ${icon} -- `,
+        colors: this.theme.block,
+      };
     }
 
     const percent = blockInfo.percentUsed;
-    const displayStyle = this.config.block.displayStyle || "bar";
+    const colors = this.getColorsForPercent(percent, this.theme.block);
+    const displayStyle = this.config.block.displayStyle || "text";
     const barWidth = this.config.block.barWidth || 10;
     const showTime = this.config.block.showTimeRemaining ?? true;
 
-    let display: string;
+    let text: string;
 
     if (displayStyle === "bar") {
-      const bar = this.formatProgressBar(percent, barWidth, this.theme);
-      display = `${bar} ${Math.round(percent)}%`;
+      const bar = this.formatProgressBar(percent, barWidth);
+      text = `${bar} ${Math.round(percent)}%`;
     } else {
-      display = `${Math.round(percent)}%`;
+      text = `${Math.round(percent)}%`;
     }
 
     // Add time remaining if available and enabled
     if (showTime && blockInfo.timeRemaining !== null) {
       const timeStr = this.formatTimeRemaining(blockInfo.timeRemaining);
-      display += ` (${timeStr} left)`;
+      text += ` (${timeStr})`;
     }
 
-    return `${this.symbols.block} ${display}`;
+    return {
+      text: ` ${icon} ${text} `,
+      colors,
+    };
   }
 
-  renderWeekly(weeklyInfo: WeeklyInfo | null): string {
+  renderWeekly(weeklyInfo: WeeklyInfo | null): Segment | null {
     if (!weeklyInfo || !this.config.weekly?.enabled) {
-      return "";
+      return null;
     }
 
+    const icon = this.usePowerline ? this.symbols.weekly : "WK";
+
     if (weeklyInfo.percentUsed === null) {
-      return `${this.symbols.weekly} --`;
+      return {
+        text: ` ${icon} -- `,
+        colors: this.theme.weekly,
+      };
     }
 
     const percent = weeklyInfo.percentUsed;
-    const displayStyle = this.config.weekly.displayStyle || "bar";
+    const displayStyle = this.config.weekly.displayStyle || "text";
     const barWidth = this.config.weekly.barWidth || 10;
     const showWeekProgress = this.config.weekly.showWeekProgress ?? true;
 
-    let display: string;
+    let text: string;
 
     if (displayStyle === "bar") {
-      const bar = this.formatProgressBar(percent, barWidth, this.theme);
-      display = `${bar} ${Math.round(percent)}%`;
+      const bar = this.formatProgressBar(percent, barWidth);
+      text = `${bar} ${Math.round(percent)}%`;
     } else {
-      display = `${Math.round(percent)}%`;
+      text = `${Math.round(percent)}%`;
     }
 
     // Add week progress if enabled
     if (showWeekProgress) {
-      display += ` (wk ${weeklyInfo.weekProgressPercent}%)`;
+      text += ` (wk ${weeklyInfo.weekProgressPercent}%)`;
     }
 
-    return `${this.symbols.weekly} ${display}`;
+    return {
+      text: ` ${icon} ${text} `,
+      colors: this.theme.weekly,
+    };
   }
 
-  render(blockInfo: BlockInfo | null, weeklyInfo: WeeklyInfo | null): string {
-    const parts: string[] = [];
+  render(
+    blockInfo: BlockInfo | null,
+    weeklyInfo: WeeklyInfo | null,
+    envInfo: EnvironmentInfo
+  ): string {
+    const segments: Segment[] = [];
 
+    // Directory/repo name
+    const dirSegment = this.renderDirectory(envInfo);
+    if (dirSegment) segments.push(dirSegment);
+
+    // Git branch
+    const gitSegment = this.renderGit(envInfo);
+    if (gitSegment) segments.push(gitSegment);
+
+    // Model
+    const modelSegment = this.renderModel(envInfo);
+    if (modelSegment) segments.push(modelSegment);
+
+    // 5-hour block usage
     const blockSegment = this.renderBlock(blockInfo);
-    if (blockSegment) {
-      parts.push(blockSegment);
-    }
+    if (blockSegment) segments.push(blockSegment);
 
+    // Weekly usage
     const weeklySegment = this.renderWeekly(weeklyInfo);
-    if (weeklySegment) {
-      parts.push(weeklySegment);
-    }
+    if (weeklySegment) segments.push(weeklySegment);
 
-    if (parts.length === 0) {
+    if (segments.length === 0) {
       return "";
     }
 
-    const separator = ` ${this.theme.separatorFg}${this.symbols.separator}${RESET_CODE} `;
-    return parts.join(separator);
+    if (this.usePowerline) {
+      return this.renderPowerline(segments);
+    } else {
+      return this.renderFallback(segments);
+    }
   }
 }

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,90 +1,132 @@
-export interface ThemeColors {
-  // Block segment
-  blockBg: string;
-  blockFg: string;
-
-  // Weekly segment
-  weeklyBg: string;
-  weeklyFg: string;
-
-  // Warning colors (when near limit)
-  warningBg: string;
-  warningFg: string;
-
-  // Critical colors (at/over limit)
-  criticalBg: string;
-  criticalFg: string;
-
-  // Progress bar colors
-  progressFull: string;
-  progressEmpty: string;
-
-  // Separator
-  separatorFg: string;
+// Segment color definition
+export interface SegmentColor {
+  bg: string;
+  fg: string;
 }
 
-// ANSI 256 color codes
-const color = (n: number) => `\x1b[38;5;${n}m`;
-const bgColor = (n: number) => `\x1b[48;5;${n}m`;
+// Theme structure matching claude-powerline
+export interface ColorTheme {
+  directory: SegmentColor;  // Repo/directory name
+  git: SegmentColor;        // Git branch
+  model: SegmentColor;      // Claude model
+  block: SegmentColor;      // 5-hour block usage
+  weekly: SegmentColor;     // 7-day weekly usage
+  warning: SegmentColor;    // Warning state (near limit)
+  critical: SegmentColor;   // Critical state (at/over limit)
+}
 
-export const themes: Record<string, ThemeColors> = {
-  dark: {
-    blockBg: bgColor(236),
-    blockFg: color(252),
-    weeklyBg: bgColor(236),
-    weeklyFg: color(252),
-    warningBg: bgColor(172),
-    warningFg: color(232),
-    criticalBg: bgColor(160),
-    criticalFg: color(255),
-    progressFull: color(76),
-    progressEmpty: color(240),
-    separatorFg: color(244),
-  },
+// Convert hex color to ANSI 256 color code
+function hexToAnsi256(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
 
-  light: {
-    blockBg: bgColor(254),
-    blockFg: color(236),
-    weeklyBg: bgColor(254),
-    weeklyFg: color(236),
-    warningBg: bgColor(214),
-    warningFg: color(232),
-    criticalBg: bgColor(196),
-    criticalFg: color(255),
-    progressFull: color(34),
-    progressEmpty: color(250),
-    separatorFg: color(244),
-  },
+  // Check for grayscale
+  if (r === g && g === b) {
+    if (r < 8) return 16;
+    if (r > 248) return 231;
+    return Math.round((r - 8) / 247 * 24) + 232;
+  }
 
-  nord: {
-    blockBg: bgColor(236),
-    blockFg: color(110),
-    weeklyBg: bgColor(236),
-    weeklyFg: color(110),
-    warningBg: bgColor(179),
-    warningFg: color(232),
-    criticalBg: bgColor(131),
-    criticalFg: color(255),
-    progressFull: color(108),
-    progressEmpty: color(239),
-    separatorFg: color(60),
-  },
+  // Convert to 6x6x6 color cube
+  const ri = Math.round(r / 255 * 5);
+  const gi = Math.round(g / 255 * 5);
+  const bi = Math.round(b / 255 * 5);
 
-  gruvbox: {
-    blockBg: bgColor(237),
-    blockFg: color(223),
-    weeklyBg: bgColor(237),
-    weeklyFg: color(223),
-    warningBg: bgColor(214),
-    warningFg: color(235),
-    criticalBg: bgColor(167),
-    criticalFg: color(235),
-    progressFull: color(142),
-    progressEmpty: color(239),
-    separatorFg: color(246),
-  },
+  return 16 + 36 * ri + 6 * gi + bi;
+}
+
+// ANSI escape code generators
+export const ansi = {
+  fg: (hex: string) => `\x1b[38;5;${hexToAnsi256(hex)}m`,
+  bg: (hex: string) => `\x1b[48;5;${hexToAnsi256(hex)}m`,
+  fgRaw: (n: number) => `\x1b[38;5;${n}m`,
+  bgRaw: (n: number) => `\x1b[48;5;${n}m`,
+  reset: '\x1b[0m',
 };
 
-export function getTheme(name: string): ThemeColors {
+// Get raw ANSI color number from hex
+export function hexToRaw(hex: string): number {
+  return hexToAnsi256(hex);
+}
+
+// Dark theme (default) - matches claude-powerline
+export const darkTheme: ColorTheme = {
+  directory: { bg: "#8b4513", fg: "#ffffff" },
+  git: { bg: "#404040", fg: "#ffffff" },
+  model: { bg: "#2d2d2d", fg: "#ffffff" },
+  block: { bg: "#2a2a2a", fg: "#87ceeb" },
+  weekly: { bg: "#1a1a1a", fg: "#98fb98" },
+  warning: { bg: "#d75f00", fg: "#ffffff" },
+  critical: { bg: "#af0000", fg: "#ffffff" },
+};
+
+// Light theme
+export const lightTheme: ColorTheme = {
+  directory: { bg: "#ff6b47", fg: "#ffffff" },
+  git: { bg: "#4fb3d9", fg: "#ffffff" },
+  model: { bg: "#87ceeb", fg: "#000000" },
+  block: { bg: "#6366f1", fg: "#ffffff" },
+  weekly: { bg: "#10b981", fg: "#ffffff" },
+  warning: { bg: "#f59e0b", fg: "#000000" },
+  critical: { bg: "#ef4444", fg: "#ffffff" },
+};
+
+// Nord theme
+export const nordTheme: ColorTheme = {
+  directory: { bg: "#434c5e", fg: "#d8dee9" },
+  git: { bg: "#3b4252", fg: "#a3be8c" },
+  model: { bg: "#4c566a", fg: "#81a1c1" },
+  block: { bg: "#3b4252", fg: "#81a1c1" },
+  weekly: { bg: "#2e3440", fg: "#8fbcbb" },
+  warning: { bg: "#d08770", fg: "#2e3440" },
+  critical: { bg: "#bf616a", fg: "#eceff4" },
+};
+
+// Gruvbox theme
+export const gruvboxTheme: ColorTheme = {
+  directory: { bg: "#504945", fg: "#ebdbb2" },
+  git: { bg: "#3c3836", fg: "#b8bb26" },
+  model: { bg: "#665c54", fg: "#83a598" },
+  block: { bg: "#3c3836", fg: "#83a598" },
+  weekly: { bg: "#282828", fg: "#fabd2f" },
+  warning: { bg: "#d79921", fg: "#282828" },
+  critical: { bg: "#cc241d", fg: "#ebdbb2" },
+};
+
+// Tokyo Night theme
+export const tokyoNightTheme: ColorTheme = {
+  directory: { bg: "#2f334d", fg: "#82aaff" },
+  git: { bg: "#1e2030", fg: "#c3e88d" },
+  model: { bg: "#191b29", fg: "#fca7ea" },
+  block: { bg: "#2d3748", fg: "#7aa2f7" },
+  weekly: { bg: "#1a202c", fg: "#4fd6be" },
+  warning: { bg: "#e0af68", fg: "#1a1b26" },
+  critical: { bg: "#f7768e", fg: "#1a1b26" },
+};
+
+// Rose Pine theme
+export const rosePineTheme: ColorTheme = {
+  directory: { bg: "#26233a", fg: "#c4a7e7" },
+  git: { bg: "#1f1d2e", fg: "#9ccfd8" },
+  model: { bg: "#191724", fg: "#ebbcba" },
+  block: { bg: "#2a273f", fg: "#eb6f92" },
+  weekly: { bg: "#232136", fg: "#9ccfd8" },
+  warning: { bg: "#f6c177", fg: "#191724" },
+  critical: { bg: "#eb6f92", fg: "#191724" },
+};
+
+// All themes
+export const themes: Record<string, ColorTheme> = {
+  dark: darkTheme,
+  light: lightTheme,
+  nord: nordTheme,
+  gruvbox: gruvboxTheme,
+  "tokyo-night": tokyoNightTheme,
+  "rose-pine": rosePineTheme,
+};
+
+// Get theme by name
+export function getTheme(name: string): ColorTheme {
   return themes[name] || themes.dark;
 }

--- a/src/utils/claude-hook.ts
+++ b/src/utils/claude-hook.ts
@@ -1,0 +1,112 @@
+import { debug } from "./logger.js";
+
+/**
+ * Hook data passed by Claude Code via stdin
+ */
+export interface ClaudeHookData {
+  hook_event_name?: string;
+  session_id?: string;
+  transcript_path?: string;
+  cwd?: string;
+  model?: {
+    id: string;
+    display_name: string;
+  };
+  workspace?: {
+    current_dir: string;
+    project_dir: string;
+  };
+  version?: string;
+}
+
+/**
+ * Read hook data from stdin (non-blocking with timeout)
+ */
+export async function readHookData(): Promise<ClaudeHookData | null> {
+  // If stdin is a TTY (interactive terminal), no hook data
+  if (process.stdin.isTTY) {
+    debug("stdin is TTY, no hook data");
+    return null;
+  }
+
+  try {
+    const chunks: Buffer[] = [];
+
+    // Read with a short timeout
+    const result = await Promise.race([
+      new Promise<string>((resolve, reject) => {
+        process.stdin.on("data", (chunk) => chunks.push(chunk));
+        process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+        process.stdin.on("error", reject);
+      }),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 100)),
+    ]);
+
+    if (!result || result.trim() === "") {
+      debug("No stdin data received");
+      return null;
+    }
+
+    const hookData = JSON.parse(result) as ClaudeHookData;
+    debug("Hook data received:", JSON.stringify(hookData));
+    return hookData;
+  } catch (error) {
+    debug("Error reading hook data:", error);
+    return null;
+  }
+}
+
+/**
+ * Format model name for compact display
+ */
+export function formatModelName(modelId: string, displayName?: string): string {
+  // If we have a display name that's reasonable, use it
+  if (displayName && displayName.length <= 20) {
+    // Clean up display name
+    const clean = displayName.replace(/^Claude\s*/i, "").trim();
+    if (clean) return clean;
+  }
+
+  // Common model ID mappings
+  const mappings: Record<string, string> = {
+    "claude-opus-4-5-20251101": "Opus 4.5",
+    "claude-opus-4-20250514": "Opus 4",
+    "claude-sonnet-4-20250514": "Sonnet 4",
+    "claude-3-5-sonnet-20241022": "Sonnet 3.5",
+    "claude-3-5-sonnet-latest": "Sonnet 3.5",
+    "claude-3-5-sonnet": "Sonnet 3.5",
+    "claude-3-opus-20240229": "Opus 3",
+    "claude-3-opus": "Opus 3",
+    "claude-3-sonnet-20240229": "Sonnet 3",
+    "claude-3-haiku-20240307": "Haiku 3",
+    "claude-3-haiku": "Haiku 3",
+  };
+
+  // Check for exact match
+  if (mappings[modelId]) {
+    return mappings[modelId];
+  }
+
+  // Try to extract a friendly name from model ID
+  const lower = modelId.toLowerCase();
+
+  if (lower.includes("opus")) {
+    if (lower.includes("4-5") || lower.includes("4.5")) return "Opus 4.5";
+    if (lower.includes("4")) return "Opus 4";
+    if (lower.includes("3")) return "Opus 3";
+    return "Opus";
+  }
+  if (lower.includes("sonnet")) {
+    if (lower.includes("4")) return "Sonnet 4";
+    if (lower.includes("3-5") || lower.includes("3.5")) return "Sonnet 3.5";
+    if (lower.includes("3")) return "Sonnet 3";
+    return "Sonnet";
+  }
+  if (lower.includes("haiku")) {
+    if (lower.includes("3")) return "Haiku 3";
+    return "Haiku";
+  }
+
+  // Return truncated original if no mapping
+  return modelId.length > 15 ? modelId.slice(0, 15) : modelId;
+}

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,0 +1,95 @@
+import { execSync } from "child_process";
+import { basename } from "path";
+import { debug } from "./logger.js";
+import { type ClaudeHookData, formatModelName } from "./claude-hook.js";
+
+/**
+ * Get the current directory/repo name
+ */
+export function getDirectoryName(hookData?: ClaudeHookData | null): string | null {
+  try {
+    // Use workspace from hook data if available
+    if (hookData?.workspace?.project_dir) {
+      return basename(hookData.workspace.project_dir);
+    }
+    if (hookData?.cwd) {
+      return basename(hookData.cwd);
+    }
+    return basename(process.cwd());
+  } catch (error) {
+    debug("Error getting directory name:", error);
+    return null;
+  }
+}
+
+/**
+ * Get the current git branch name
+ */
+export function getGitBranch(): string | null {
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return branch || null;
+  } catch (error) {
+    debug("Error getting git branch:", error);
+    return null;
+  }
+}
+
+/**
+ * Check if the git repo has uncommitted changes
+ */
+export function hasGitChanges(): boolean {
+  try {
+    const status = execSync("git status --porcelain", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return status.length > 0;
+  } catch (error) {
+    debug("Error checking git status:", error);
+    return false;
+  }
+}
+
+/**
+ * Get the Claude model from hook data or environment variable
+ */
+export function getClaudeModel(hookData?: ClaudeHookData | null): string | null {
+  // First try hook data (most reliable)
+  if (hookData?.model?.id) {
+    return formatModelName(hookData.model.id, hookData.model.display_name);
+  }
+
+  // Fall back to environment variables
+  const model = process.env.CLAUDE_MODEL
+    || process.env.CLAUDE_CODE_MODEL
+    || process.env.ANTHROPIC_MODEL;
+
+  if (model) {
+    return formatModelName(model);
+  }
+
+  return null;
+}
+
+export interface EnvironmentInfo {
+  directory: string | null;
+  gitBranch: string | null;
+  gitDirty: boolean;
+  model: string | null;
+}
+
+/**
+ * Get all environment info at once
+ */
+export function getEnvironmentInfo(hookData?: ClaudeHookData | null): EnvironmentInfo {
+  return {
+    directory: getDirectoryName(hookData),
+    gitBranch: getGitBranch(),
+    gitDirty: hasGitChanges(),
+    model: getClaudeModel(hookData),
+  };
+}


### PR DESCRIPTION
## Summary

- Add new segments: directory/repo name, git branch, Claude model
- Add 6 themes from claude-powerline: dark, light, nord, gruvbox, tokyo-night, rose-pine
- Read hook data from stdin (Claude Code passes model info this way)
- Fix model name formatting (Opus 4.5, Sonnet 4, etc.)
- Powerline-style arrows between colored segments

## New Segments

| Segment | Description | Example |
|---------|-------------|---------|
| **Directory** | Current repo/project name | `claude-limitline` |
| **Git** | Branch name + dirty indicator | `main ●` |
| **Model** | Claude model name | `Opus 4.5` |
| **Block** | 5-hour usage + time remaining | `12% (3h20m)` |
| **Weekly** | 7-day usage + week progress | `45% (wk 85%)` |

## Example Output

```
 claude-limitline  main ●   Opus 4.5   12% (3h20m)   45% (wk 85%)
```

## Test plan

- [ ] Run `npm run build` - should compile without errors
- [ ] Run `echo '{"model":{"id":"claude-opus-4-5-20251101"}}' | node dist/index.js` - should show all segments
- [ ] Test different themes by setting `"theme": "tokyo-night"` in config
- [ ] Verify model names display correctly (Opus 4.5, Sonnet 4, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)