### PR TITLE
Add full settings example back to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ npm link
 
 ## Quick Start
 
-Add claude-limitline to your Claude Code settings file (`~/.claude/settings.json`):
+The easiest way to use claude-limitline is to add it directly to your Claude Code settings.
+
+**Add to your Claude Code settings file** (`~/.claude/settings.json`):
 
 ```json
 {
@@ -61,7 +63,23 @@ Add claude-limitline to your Claude Code settings file (`~/.claude/settings.json
 }
 ```
 
-That's it! The status line will now show in Claude Code.
+That's it! The status line will now show your usage limits in Claude Code.
+
+### Full Settings Example
+
+Here's a complete example with other common settings:
+
+```json
+{
+  "permissions": {
+    "defaultMode": "default"
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "npx claude-limitline"
+  }
+}
+```
 
 ### Global Install (faster startup)
 


### PR DESCRIPTION
## Summary

- Restore the complete `settings.json` example in the Quick Start section
- Shows npx usage alongside other common Claude Code settings like permissions

## Changes

Added the "Full Settings Example" subsection back to README:

```json
{
  "permissions": {
    "defaultMode": "default"
  },
  "statusLine": {
    "type": "command",
    "command": "npx claude-limitline"
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)