### PR TITLE
Add context percentage segment on right side with left arrows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage/
 
 # Config (may contain sensitive paths)
 .claude-limitline.json
+CLAUDE.local.md

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -34,7 +34,7 @@ export interface DisplayConfig {
   compactWidth?: number;  // Terminal width threshold for compact mode (default 80)
 }
 
-export type SegmentName = "directory" | "git" | "model" | "block" | "weekly";
+export type SegmentName = "directory" | "git" | "model" | "block" | "weekly" | "context";
 
 export interface LimitlineConfig {
   display?: DisplayConfig;
@@ -43,6 +43,7 @@ export interface LimitlineConfig {
   model?: SimpleSegmentConfig;      // Show Claude model
   block?: BlockSegmentConfig;
   weekly?: WeeklySegmentConfig;
+  context?: SimpleSegmentConfig;    // Show context window usage (right side)
   budget?: BudgetConfig;
   theme?: string;
   segmentOrder?: SegmentName[];     // Custom order for segments
@@ -77,6 +78,9 @@ export const DEFAULT_CONFIG: LimitlineConfig = {
     barWidth: 10,
     showWeekProgress: true,
     viewMode: "simple",
+  },
+  context: {
+    enabled: true,
   },
   budget: {
     pollInterval: 15,

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -13,6 +13,7 @@ export interface ColorTheme {
   weekly: SegmentColor;     // 7-day weekly usage
   opus: SegmentColor;       // Opus-specific weekly usage
   sonnet: SegmentColor;     // Sonnet-specific weekly usage
+  context: SegmentColor;    // Context window usage
   warning: SegmentColor;    // Warning state (near limit)
   critical: SegmentColor;   // Critical state (at/over limit)
 }
@@ -61,6 +62,7 @@ export const darkTheme: ColorTheme = {
   weekly: { bg: "#1a1a1a", fg: "#98fb98" },
   opus: { bg: "#1a1a1a", fg: "#c792ea" },      // Purple for Opus
   sonnet: { bg: "#1a1a1a", fg: "#89ddff" },    // Light blue for Sonnet
+  context: { bg: "#2a2a2a", fg: "#87ceeb" },   // Sky blue for context
   warning: { bg: "#d75f00", fg: "#ffffff" },
   critical: { bg: "#af0000", fg: "#ffffff" },
 };
@@ -74,6 +76,7 @@ export const lightTheme: ColorTheme = {
   weekly: { bg: "#10b981", fg: "#ffffff" },
   opus: { bg: "#8b5cf6", fg: "#ffffff" },      // Purple for Opus
   sonnet: { bg: "#0ea5e9", fg: "#ffffff" },    // Sky blue for Sonnet
+  context: { bg: "#6366f1", fg: "#ffffff" },   // Indigo for context
   warning: { bg: "#f59e0b", fg: "#000000" },
   critical: { bg: "#ef4444", fg: "#ffffff" },
 };
@@ -87,6 +90,7 @@ export const nordTheme: ColorTheme = {
   weekly: { bg: "#2e3440", fg: "#8fbcbb" },
   opus: { bg: "#2e3440", fg: "#b48ead" },      // Nord purple for Opus
   sonnet: { bg: "#2e3440", fg: "#88c0d0" },    // Nord frost for Sonnet
+  context: { bg: "#3b4252", fg: "#81a1c1" },   // Nord frost for context
   warning: { bg: "#d08770", fg: "#2e3440" },
   critical: { bg: "#bf616a", fg: "#eceff4" },
 };
@@ -100,6 +104,7 @@ export const gruvboxTheme: ColorTheme = {
   weekly: { bg: "#282828", fg: "#fabd2f" },
   opus: { bg: "#282828", fg: "#d3869b" },      // Gruvbox purple for Opus
   sonnet: { bg: "#282828", fg: "#8ec07c" },    // Gruvbox aqua for Sonnet
+  context: { bg: "#3c3836", fg: "#83a598" },   // Gruvbox blue for context
   warning: { bg: "#d79921", fg: "#282828" },
   critical: { bg: "#cc241d", fg: "#ebdbb2" },
 };
@@ -113,6 +118,7 @@ export const tokyoNightTheme: ColorTheme = {
   weekly: { bg: "#1a202c", fg: "#4fd6be" },
   opus: { bg: "#1a202c", fg: "#bb9af7" },      // Tokyo purple for Opus
   sonnet: { bg: "#1a202c", fg: "#7dcfff" },    // Tokyo cyan for Sonnet
+  context: { bg: "#2d3748", fg: "#7aa2f7" },   // Tokyo blue for context
   warning: { bg: "#e0af68", fg: "#1a1b26" },
   critical: { bg: "#f7768e", fg: "#1a1b26" },
 };
@@ -126,6 +132,7 @@ export const rosePineTheme: ColorTheme = {
   weekly: { bg: "#232136", fg: "#9ccfd8" },
   opus: { bg: "#232136", fg: "#c4a7e7" },      // Rose Pine iris for Opus
   sonnet: { bg: "#232136", fg: "#31748f" },    // Rose Pine pine for Sonnet
+  context: { bg: "#2a273f", fg: "#9ccfd8" },   // Rose Pine foam for context
   warning: { bg: "#f6c177", fg: "#191724" },
   critical: { bg: "#eb6f92", fg: "#191724" },
 };

--- a/src/utils/claude-hook.ts
+++ b/src/utils/claude-hook.ts
@@ -16,6 +16,14 @@ export interface ClaudeHookData {
     current_dir: string;
     project_dir: string;
   };
+  context_window?: {
+    current_usage: {
+      input_tokens: number;
+      cache_creation_input_tokens: number;
+      cache_read_input_tokens: number;
+    };
+    context_window_size: number;
+  };
   version?: string;
 }
 

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -80,6 +80,25 @@ export interface EnvironmentInfo {
   gitBranch: string | null;
   gitDirty: boolean;
   model: string | null;
+  contextPercent: number;
+}
+
+/**
+ * Calculate context window usage percentage from hook data
+ */
+export function getContextPercent(hookData?: ClaudeHookData | null): number {
+  const ctx = hookData?.context_window;
+  if (!ctx?.current_usage || !ctx.context_window_size) {
+    return 0;
+  }
+
+  const usage = ctx.current_usage;
+  const totalTokens =
+    (usage.input_tokens || 0) +
+    (usage.cache_creation_input_tokens || 0) +
+    (usage.cache_read_input_tokens || 0);
+
+  return Math.round((totalTokens / ctx.context_window_size) * 100);
 }
 
 /**
@@ -91,5 +110,6 @@ export function getEnvironmentInfo(hookData?: ClaudeHookData | null): Environmen
     gitBranch: getGitBranch(),
     gitDirty: hasGitChanges(),
     model: getClaudeModel(hookData),
+    contextPercent: getContextPercent(hookData),
   };
 }


### PR DESCRIPTION
## Summary
- Adds context window usage percentage display at the end of the limitline
- Uses left-pointing powerline arrows (vim statusline style)
- Context percentage calculated from hook data token counts

## Changes
- Add `context_window` field to `ClaudeHookData` type
- Add `contextPercent` calculation to `EnvironmentInfo`
- Add `context` color to all themes (dark, light, nord, gruvbox, tokyo-night, rose-pine)
- Add `renderRightPowerline()` for right-side segments with left arrows
- Context segment always appears on right side, enabled by default

## Visual Result
```
 dir > branch > model > block > weekly  < ◐ 25% 
└────────── left side ──────────────┘   └─ right ─┘
           (→ arrows)                    (← arrow)
```
