### PR TITLE
Fix macOS Keychain OAuth token retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,15 @@ claude-limitline retrieves data from two sources:
 
 ### OAuth Token Location
 
+The tool automatically retrieves your OAuth token from Claude Code's credential storage:
+
 | Platform | Location |
 |----------|----------|
+| **macOS** | Keychain (`Claude Code-credentials` service) |
 | **Windows** | Credential Manager or `~/.claude/.credentials.json` |
-| **macOS** | Keychain or `~/.claude/.credentials.json` |
 | **Linux** | secret-tool (GNOME Keyring) or `~/.claude/.credentials.json` |
+
+> **Note:** On macOS, the token is read directly from the system Keychain where Claude Code stores it. No additional configuration is needed—just make sure you're logged into Claude Code (`claude --login`).
 
 ## Development
 
@@ -191,7 +195,7 @@ npm run dev      # Watch mode
 
 ## Testing
 
-The project uses [Vitest](https://vitest.dev/) for testing with 164 tests covering config loading, themes, segments, utilities, and rendering.
+The project uses [Vitest](https://vitest.dev/) for testing with 170 tests covering config loading, themes, segments, utilities, and rendering.
 
 ```bash
 npm test              # Run tests once
@@ -207,7 +211,7 @@ npm run test:coverage # Coverage report
 | `src/themes/index.test.ts` | 37 | Theme retrieval, color validation |
 | `src/segments/block.test.ts` | 8 | Block segment, time calculations |
 | `src/segments/weekly.test.ts` | 13 | Weekly segment, week progress |
-| `src/utils/oauth.test.ts` | 13 | API responses, caching, trends |
+| `src/utils/oauth.test.ts` | 19 | API responses, caching, trends, macOS keychain |
 | `src/utils/claude-hook.test.ts` | 21 | Model name formatting |
 | `src/utils/environment.test.ts` | 20 | Git branch, directory detection |
 | `src/utils/terminal.test.ts` | 13 | Terminal width, ANSI handling |


### PR DESCRIPTION
## Summary

- Fixes OAuth token retrieval on macOS by using the correct keychain service name (`Claude Code-credentials` instead of `Claude Code`)
- Parses the JSON structure stored in keychain (`{"claudeAiOauth":{"accessToken":"..."}}`) instead of expecting a raw token
- Adds fallback to raw token format for compatibility

**Before:** Status line showed `-- --` for usage values on macOS
**After:** Status line correctly displays usage percentages (e.g., `◫ 16% (2h19m)`)

## Test plan

- [x] Verified OAuth token is correctly retrieved from macOS Keychain
- [x] Added 6 new tests for macOS keychain retrieval scenarios
- [x] All 170 tests pass
- [x] Built and tested locally - status line now shows real usage data
- [x] Updated README to clarify macOS Keychain support

🤖 Generated with [Claude Code](https://claude.com/claude-code)